### PR TITLE
Linux support

### DIFF
--- a/.electron-vite/build.js
+++ b/.electron-vite/build.js
@@ -9,7 +9,7 @@ const rollup = require("rollup")
 const { build } = require('vite')
 const Multispinner = require('multispinner')
 
-const mainOptions = require('./rollup.Main.config');
+const mainOptions = require('./rollup.main.config');
 const rendererOptions = require('./vite.config')
 const opt = mainOptions(process.env.NODE_ENV);
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:win32": "cross-env BUILD_TARGET=clean node .electron-vite/build.js && node .electron-vite/build.js && electron-builder --win  --ia32",
     "build:win64": "cross-env BUILD_TARGET=clean node .electron-vite/build.js && node .electron-vite/build.js && electron-builder --win  --x64",
     "build:mac": "cross-env BUILD_TARGET=clean node .electron-vite/build.js && node .electron-vite/build.js && electron-builder --mac",
+    "build:linux": "cross-env BUILD_TARGET=clean node .electron-vite/build.js && node .electron-vite/build.js && electron-builder --linux",
     "build:dir": "cross-env BUILD_TARGET=clean node .electron-vite/build.js && node .electron-vite/build.js && electron-builder --dir",
     "build:clean": "cross-env BUILD_TARGET=clean node .electron-vite/build.js",
     "build:web": "cross-env BUILD_TARGET=web node .electron-vite/build.js",

--- a/src/main/getData.js
+++ b/src/main/getData.js
@@ -125,7 +125,12 @@ const detectGameLocale = async (userPath) => {
 const readLog = async () => {
   const text = i18n.log
   try {
-    const userPath = app.getPath('home')
+    let userPath
+    if (!process.env.WINEPREFIX) {
+      userPath = app.getPath('home')
+    } else {
+      userPath = path.join(process.env.WINEPREFIX, 'drive_c/users', process.env.USER)
+    }
     const gameNames = await detectGameLocale(userPath)
     if (!gameNames.length) {
       sendMsg(text.file.notFound)


### PR DESCRIPTION
A few small changes are needed to support Genshin Impact on Linux running through wine.

- if WINEPREFIX is set, use that for userPath
- fix case mismatch in .electron-vite/build.js
- add npm build script for linux