### PR TITLE
fix: getQuerystring may cause read data infinite loop

### DIFF
--- a/src/main/getData.js
+++ b/src/main/getData.js
@@ -278,6 +278,7 @@ const getQuerystring = (url) => {
   searchParams.delete('page')
   searchParams.delete('size')
   searchParams.delete('gacha_type')
+  searchParams.delete('end_id')
   return searchParams
 }
 


### PR DESCRIPTION
When use manually url input (#46), getQuerystring may cause read data infinite loop.