### PR TITLE
feat: 简单支持了下星穹铁道

### DIFF
--- a/src/main/getData.js
+++ b/src/main/getData.js
@@ -306,7 +306,7 @@ const fixAuthkey = (url) => {
 const getQuerystring = (url) => {
   const text = i18n.log
   const { searchParams, host } = new URL(fixAuthkey(url))
-  if (host.includes('webstatic-sea') || host.includes('hk4e-api-os')) {
+  if (host.includes('webstatic-sea') || host.includes('hkrpg-api-os')) {
     // 国际服地址参照了 https://github.com/Scighost/StarRailTool/blob/main/StarRailTool/Gacha/GachaLogClient.cs#LL22
     apiDomain = 'https://api-os-takumi.mihoyo.com'
   } else {


### PR DESCRIPTION
看到最近 Issue #194 和 #186 都希望出一个 崩坏：星穹铁道 版本的，我就把 `src/main/getData.js` 改了改，简单搓了一个可用的，仅供抛砖引玉吧

主要修改如下：
1. 适配了铁道的日志文件夹地址和日志文件，铁道是在 Player-prev.log 这个文件里面记录了游戏本体路径
2. 适配了铁道的获取抽卡日志 API
3. 目前我没有在铁道里面找到类似 getConfigList 这样的，用于获取卡池详情的接口，因此目前的 gacha_type 只能依赖于程序里面写死的 defaultTypeMap 了，另外也就注释掉了 tryRequest 和 getGachaType 这两个方法的相关调用

我自己测了国服下正常的日志模式和代理模式，感觉都能获取到数据，国际服未测（我不玩国际服），附截图
![image](https://user-images.githubusercontent.com/56069009/235287827-2921d92f-f6a7-49fb-b947-caaad28804eb.png)
