### PR TITLE
可导出的JSON可直接同步至Github Gists

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "dependencies": {},
   "devDependencies": {
     "@element-plus/icons-vue": "^0.2.6",
+    "@octokit/core": "^5.0.0",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -9,7 +9,9 @@ const config = {
   proxyMode: false,
   autoUpdate: true,
   fetchFullHistory: false,
-  hideNovice: true
+  hideNovice: true,
+  gistsToken: '',
+  gistsId: ''
 }
 
 const getLocalConfig = async () => {

--- a/src/main/gists.js
+++ b/src/main/gists.js
@@ -1,0 +1,123 @@
+const {app, ipcMain, dialog} = require('electron')
+const fs = require('fs-extra')
+const path = require('path')
+const getData = require('./getData').getData
+const {version} = require('../../package.json')
+const config = require('./config')
+const {Octokit} = require('@octokit/core')
+const fetch = require('electron-fetch').default
+const getTimeString = () => {
+    return new Date().toLocaleString('sv').replace(/[- :]/g, '').slice(0, -2)
+}
+
+const formatDate = (date) => {
+    let y = date.getFullYear()
+    let m = `${date.getMonth() + 1}`.padStart(2, '0')
+    let d = `${date.getDate()}`.padStart(2, '0')
+    return `${y}-${m}-${d} ${date.toLocaleString('zh-cn', {hour12: false}).slice(-8)}`
+}
+
+const fakeIdFn = () => {
+    let id = 1000000000000000000n
+    return () => {
+        id = id + 1n
+        return id.toString()
+    }
+}
+
+const shouldBeString = (value) => {
+    if (typeof value !== 'string') {
+        return ''
+    }
+    return value
+}
+
+const start = async () => {
+    const {dataMap, current} = await getData()
+    const data = dataMap.get(current)
+    if (!data?.result.size) {
+        throw new Error('数据为空')
+    }
+    const fakeId = fakeIdFn()
+    const result = {
+        info: {
+            uid: data.uid,
+            lang: data.lang,
+            export_time: formatDate(new Date()),
+            export_timestamp: Date.now(),
+            export_app: 'genshin-wish-export',
+            export_app_version: `v${version}`,
+            uigf_version: 'v2.2'
+        },
+        list: []
+    }
+    const listTemp = []
+    for (let [type, arr] of data.result) {
+        arr.forEach(item => {
+            listTemp.push({
+                gacha_type: shouldBeString(item[4]) || type,
+                time: item[0],
+                timestamp: new Date(item[0]).getTime(),
+                name: item[1],
+                item_type: item[2],
+                rank_type: `${item[3]}`,
+                id: shouldBeString(item[5]) || '',
+                uigf_gacha_type: type
+            })
+        })
+    }
+    listTemp.sort((a, b) => a.timestamp - b.timestamp)
+    listTemp.forEach(item => {
+        delete item.timestamp
+        result.list.push({
+            ...item,
+            id: item.id || fakeId()
+        })
+    })
+
+    if (!config.gistsToken) {
+        throw new Error('未设置gistsToken')
+    }
+
+    const octokit = new Octokit({
+        request: {fetch: fetch},
+        auth: config.gistsToken
+    })
+
+    if (config.gistsId) {
+        await octokit.request('PATCH /gists/{gist_id}', {
+            gist_id: config.gistsId,
+            files: {
+                // 这里文件名不需要加时间戳，加入时间戳会产生多个文件
+                [`UIGF_${data.uid}.json`]: {
+                    content: JSON.stringify(result, null, 2)
+                }
+            },
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+            }
+        })
+    } else {
+        const response = await octokit.request('POST /gists', {
+            description: 'genshin-wish-export',
+            'public': false,
+            files: {
+                [`UIGF_${data.uid}.json`]: {
+                    content: JSON.stringify(result, null, 2)
+                }
+            },
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+            }
+        })
+        if (response.status === 201) {
+            config["gistsId"] = response.data.id
+            await config.save()
+        }
+    }
+
+}
+
+ipcMain.handle('EXPORT_UIGF_JSON_GISTS', async () => {
+    await start()
+})

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -4,6 +4,7 @@ const { disableProxy, proxyStatus } = require('./module/system-proxy')
 require('./getData')
 require('./excel')
 require('./UIGFJson')
+require('./gists')
 const { getUpdateInfo } = require('./update/index')
 
 const isDev = !app.isPackaged

--- a/src/renderer/components/Setting.vue
+++ b/src/renderer/components/Setting.vue
@@ -54,7 +54,7 @@
           <a class="cursor-pointer text-blue-400" @click="openLink('https://github.com/DGP-Studio/Snap.Genshin/wiki/StandardFormat#export_app')">统一可交换祈愿记录标准</a>
         </p>
       </el-form-item>
-      <el-form-item v-if="settingForm.lang === 'zh-cn'" label="导出到Github Gists">
+      <el-form-item label="导出到Github Gists">
         <el-input placeholder="请输入内容" v-model="settingForm.gistsToken" :disabled="gistsConfigDisabled">
           <template #append>
             <el-button v-show="gistsConfigDisabled" @click="configGistsToken">设置Token</el-button>
@@ -63,7 +63,7 @@
         </el-input>
         <p class="text-gray-400 text-xs m-1.5 leading-normal">该功能用于将抽卡记录同步至Github Gists，单击“设置Token”按钮，本地浏览器将会跳转至GithubTokens设置页面，新增您的个人Token，并打开Gists功能的读写权限，最后将新生成的Token存入这里，单击“保存Token”完成设置</p>
         <el-button @click="uploadGists" type="success" plain class="focus:outline-none" :disabled="!settingForm.gistsToken" :loading="uploadGistsLoading">同步至Gists</el-button>
-        <p class="text-gray-400 text-xs m-1.5 leading-normal">使用这个功能的前提是您的网络可以正常访问Github Gists，目前仅支持简体中文模式。<br>支持的工具参考这个链接：
+        <p class="text-gray-400 text-xs m-1.5 leading-normal">使用这个功能的前提是您的网络可以正常访问Github Gists。<br>支持的工具参考这个链接：
           <a class="cursor-pointer text-blue-400" @click="openLink('https://github.com/DGP-Studio/Snap.Genshin/wiki/StandardFormat#export_app')">统一可交换祈愿记录标准</a>
         </p>
       </el-form-item>

--- a/src/renderer/components/Setting.vue
+++ b/src/renderer/components/Setting.vue
@@ -54,6 +54,18 @@
           <a class="cursor-pointer text-blue-400" @click="openLink('https://github.com/DGP-Studio/Snap.Genshin/wiki/StandardFormat#export_app')">统一可交换祈愿记录标准</a>
         </p>
       </el-form-item>
+      <el-form-item v-if="settingForm.lang === 'zh-cn'" label="导出到Github Gists">
+        <el-input placeholder="请输入内容" v-model="settingForm.gistsToken" :disabled="gistsConfigDisabled">
+          <template #append>
+            <el-button v-show="gistsConfigDisabled" @click="configGistsToken">设置Token</el-button>
+            <el-button v-show="!gistsConfigDisabled" @click="saveGistsToken" type="success" plain class="focus:outline-none">保存Token</el-button>
+          </template>
+        </el-input>
+        <el-button @click="uploadGists" type="success" plain class="focus:outline-none">上传至Gists</el-button>
+        <p class="text-gray-400 text-xs m-1.5 leading-normal">该功能用于导出数据到其它抽卡记录管理工具，仅支持简体中文模式。<br>支持的工具参考这个链接：
+          <a class="cursor-pointer text-blue-400" @click="openLink('https://github.com/DGP-Studio/Snap.Genshin/wiki/StandardFormat#export_app')">统一可交换祈愿记录标准</a>
+        </p>
+      </el-form-item>
     </el-form>
     <h3 class="text-lg my-4">{{about.title}}</h3>
     <p class="text-gray-600 text-xs mt-1">{{about.license}}</p>
@@ -63,7 +75,7 @@
 
 <script setup>
 const { ipcRenderer, shell } = require('electron')
-import { reactive, onMounted, computed } from 'vue'
+import { ref, reactive, onMounted, computed } from 'vue'
 
 const emit = defineEmits(['close', 'changeLang'])
 
@@ -81,14 +93,15 @@ const settingForm = reactive({
   proxyMode: true,
   autoUpdate: true,
   fetchFullHistory: false,
-  hideNovice: true
+  hideNovice: true,
+  gistsToken: ''
 })
 
 const text = computed(() => props.i18n.ui.setting)
 const about = computed(() => props.i18n.ui.about)
 
 const saveSetting = async () => {
-  const keys = ['lang', 'logType', 'proxyMode', 'autoUpdate', 'fetchFullHistory', 'hideNovice']
+  const keys = ['lang', 'logType', 'proxyMode', 'autoUpdate', 'fetchFullHistory', 'hideNovice', 'gistsToken']
   for (let key of keys) {
     await ipcRenderer.invoke('SAVE_CONFIG', [key, settingForm[key]])
   }
@@ -110,6 +123,22 @@ const openLink = (link) => shell.openExternal(link)
 
 const exportUIGFJSON = () => {
   ipcRenderer.invoke('EXPORT_UIGF_JSON')
+}
+
+const gistsConfigDisabled = ref(true)
+
+const configGistsToken = () => {
+  gistsConfigDisabled.value = false
+  openLink('https://github.com/settings/personal-access-tokens/new')
+}
+
+const saveGistsToken = async () => {
+  gistsConfigDisabled.value = true
+  await saveSetting()
+}
+
+const uploadGists = () => {
+  ipcRenderer.invoke('EXPORT_UIGF_JSON_GISTS')
 }
 
 onMounted(async () => {

--- a/src/renderer/components/Setting.vue
+++ b/src/renderer/components/Setting.vue
@@ -61,8 +61,9 @@
             <el-button v-show="!gistsConfigDisabled" @click="saveGistsToken" type="success" plain class="focus:outline-none">保存Token</el-button>
           </template>
         </el-input>
-        <el-button @click="uploadGists" type="success" plain class="focus:outline-none">上传至Gists</el-button>
-        <p class="text-gray-400 text-xs m-1.5 leading-normal">该功能用于导出数据到其它抽卡记录管理工具，仅支持简体中文模式。<br>支持的工具参考这个链接：
+        <p class="text-gray-400 text-xs m-1.5 leading-normal">该功能用于将抽卡记录同步至Github Gists，单击“设置Token”按钮，本地浏览器将会跳转至GithubTokens设置页面，新增您的个人Token，并打开Gists功能的读写权限，最后将新生成的Token存入这里，单击“保存Token”完成设置</p>
+        <el-button @click="uploadGists" type="success" plain class="focus:outline-none" :disabled="!settingForm.gistsToken" :loading="uploadGistsLoading">同步至Gists</el-button>
+        <p class="text-gray-400 text-xs m-1.5 leading-normal">目前仅支持简体中文模式。<br>支持的工具参考这个链接：
           <a class="cursor-pointer text-blue-400" @click="openLink('https://github.com/DGP-Studio/Snap.Genshin/wiki/StandardFormat#export_app')">统一可交换祈愿记录标准</a>
         </p>
       </el-form-item>
@@ -137,8 +138,10 @@ const saveGistsToken = async () => {
   await saveSetting()
 }
 
-const uploadGists = () => {
-  ipcRenderer.invoke('EXPORT_UIGF_JSON_GISTS')
+const uploadGistsLoading = ref(false)
+const uploadGists = async () => {
+  uploadGistsLoading.value = true
+  uploadGistsLoading.value = !(await ipcRenderer.invoke('EXPORT_UIGF_JSON_GISTS'))
 }
 
 onMounted(async () => {

--- a/src/renderer/components/Setting.vue
+++ b/src/renderer/components/Setting.vue
@@ -63,7 +63,7 @@
         </el-input>
         <p class="text-gray-400 text-xs m-1.5 leading-normal">该功能用于将抽卡记录同步至Github Gists，单击“设置Token”按钮，本地浏览器将会跳转至GithubTokens设置页面，新增您的个人Token，并打开Gists功能的读写权限，最后将新生成的Token存入这里，单击“保存Token”完成设置</p>
         <el-button @click="uploadGists" type="success" plain class="focus:outline-none" :disabled="!settingForm.gistsToken" :loading="uploadGistsLoading">同步至Gists</el-button>
-        <p class="text-gray-400 text-xs m-1.5 leading-normal">目前仅支持简体中文模式。<br>支持的工具参考这个链接：
+        <p class="text-gray-400 text-xs m-1.5 leading-normal">使用这个功能的前提是您的网络可以正常访问Github Gists，目前仅支持简体中文模式。<br>支持的工具参考这个链接：
           <a class="cursor-pointer text-blue-400" @click="openLink('https://github.com/DGP-Studio/Snap.Genshin/wiki/StandardFormat#export_app')">统一可交换祈愿记录标准</a>
         </p>
       </el-form-item>


### PR DESCRIPTION
功能步骤：
1、主界面点击“更新数据” 
2、打开”选项“-”设置“
3、”导出到Github Gists“-”设置Token“ ，此时输入框被激活，本地浏览器打开Github Tokens设置页面(前提是本地浏览器已登录Github，如果未登录，则需要登录后操作)
4、在Github Tokens页面中添加新的Tokens 如下图所示
![msedge_euZ8xp5h5u](https://github.com/biuuu/genshin-wish-export/assets/16286533/4d9abfc5-4436-49da-8ea0-c66935a2f296)
添加完成后页面会有一次复制私有token的机会
![msedge_LVu6cMnWRN](https://github.com/biuuu/genshin-wish-export/assets/16286533/bfc54624-c71f-4daa-9d89-a87bd2236ab3)
5、将复制到的Token填入程序输入框，单击”保存Token“，此时”同步至Gists“按钮被激活
6、”同步至Gists“
