### PR TITLE
fix(package): homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.1",
   "main": "./dist/electron/main/main.js",
   "author": "biuuu <https://github.com/biuuu>",
+  "homepage": "https://github.com/biuuu/genshin-wish-export",
   "license": "MIT",
   "scripts": {
     "dev": "node .electron-vite/dev-runner.js",


### PR DESCRIPTION
Accoding of the [Document](https://www.electron.build/configuration/configuration#metadata),

`homepage String | “undefined” - The url to the project [homepage](https://docs.npmjs.com/files/package.json#homepage) (NuGet Package projectUrl (optional) or Linux Package URL (required)).`

Add homepage to package.json for linux build.