### PR TITLE
fix #259

### DIFF
--- a/src/main/UIGFJson.js
+++ b/src/main/UIGFJson.js
@@ -241,7 +241,7 @@ const importJson = async () => {
     else {
       // try to fix imported data when possible
       fixUigfJson(importData)
-      // then valid imported data using schema
+      // then validate imported data using schema
       if (validateUigfJson(importData)) {
         const gachaData = {
           result: new Map(),


### PR DESCRIPTION
fix #259 

为什么会出现这个问题：
在最新的版本中，我添加了修复Uigf Json数据的功能:
`const importData = fixUigfJson(JSON.parse(jsonStr))`

但问题在于，jsonStr并不只有可能是Uigf json文件，也有可能是gacha-list json文件。
虽然这并没有明确提及，但我在很早的提交中已经实现了这个功能。但最新的修改或导致gacha-list文件也会被“修复”。

最新的修改保证了fixUigfJson不再会修复gacha-list json文件，现在导入数据可以重新正常地导入gacha-list json文件了。