### PR TITLE
Fixed up the UIGF api calls as /all.json is not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@vitejs/plugin-vue": "2.1.0",
     "@vue/compiler-sfc": "^3.2.29",
     "adm-zip": "^0.5.9",
-    "ajv": "6",
+    "ajv": "8.17.1",
     "autoprefixer": "^10.4.2",
     "cfonts": "^2.10.0",
     "chalk": "^4.1.0",

--- a/src/i18n/English.json
+++ b/src/i18n/English.json
@@ -56,6 +56,7 @@
   "ui.setting.UIGFLink": "Uniformed Interchangeable GachaLog Format Standard",
   "ui.setting.UIGFLable": "Import / Export",
   "ui.setting.UIGFButton": "Export data",
+  "ui.setting.UIGFAllAccounts": "Export all accounts",
   "ui.setting.UIGFReadable": "Readable",
   "ui.about.title": "About",
   "ui.about.license": "This software is opensource using MIT license.",

--- a/src/i18n/简体中文.json
+++ b/src/i18n/简体中文.json
@@ -56,6 +56,7 @@
   "ui.setting.UIGFLink": "统一可交换抽卡记录标准",
   "ui.setting.UIGFLable": "导入/导出",
   "ui.setting.UIGFButton": "导出数据",
+  "ui.setting.UIGFAllAccounts": "导出全部账号",
   "ui.setting.UIGFReadable": "可读",
   "ui.about.title": "关于",
   "ui.about.license": "本工具为开源软件，源代码使用 MIT 协议授权",

--- a/src/main/UIGFJson.js
+++ b/src/main/UIGFJson.js
@@ -6,7 +6,7 @@ const getItemTypeNameMap = require('./gachaTypeMap').getItemTypeNameMap
 const { version } = require('../../package.json')
 const config = require('./config')
 const fetch = require('electron-fetch').default
-const { readJSON, saveJSON, existsFile, userDataPath, fixLocalMap } = require('./utils')
+const { readJSON, saveJSON, existsFile, userDataPath, fixLocalMap, md5, mapToObject } = require('./utils')
 const Ajv = require('ajv')
 
 // acquire uigf schema
@@ -21,7 +21,7 @@ const uigfLangMap = new Map([
   ['es-es', 'es'],
   ['fr-fr', 'fr'],
   ['id-id', 'id'],
-  ['ja-jp', 'ja'],
+  ['ja-jp', 'jp'],
   ['ko-kr', 'kr'],
   ['pt-pt', 'pt'],
   ['ru-ru', 'ru'],
@@ -58,70 +58,75 @@ const shouldBeString = (value) => {
 // a dictionary for looking up item ids
 const itemIdDict = new Map()
 // the md5 value for the dictionary
-let itemIdDictMd5 = null
+const itemIdDictMd5 = new Map()
 // the file name for saving item id dictionary
 const itemIdDictFileName = 'item-id-dict.json'
 
 // acquire dictionary based on give language
 const fetchItemIdDict = async (lang = 'all') => {
-  // fetch item id dict from api.uigf.org
-  const response = await fetch(`https://api.uigf.org/dict/genshin/${lang}.json`)
-  // update local dict
-  Object.entries(await response.json()).forEach(
-    ([lang, table]) => itemIdDict.set(
-      // assign item id table based on language, and convert all id from number to string
-      lang, new Map(Object.entries(table).map(([name, id]) => [name, String(id)]))
-    )
-  )
+  // fetch item id dicts from api.uigf.org
+  for (const [_, lang] of uigfLangMap) {
+    const response = await fetch(`https://api.uigf.org/dict/genshin/${lang}.json`)
+    const responseText = await response.text().catch((e) => console.error(e))
+    const responseJson = JSON.parse(responseText)
+    itemIdDict.set(lang, new Map(Object.entries(responseJson).map(([name, id]) => [name, String(id)])))
+    itemIdDictMd5.set(lang, md5(responseText))
+  }
 }
 
 // acquire dictionary based on give language
 const fetchItemIdDictMd5 = async (lang = 'all') => {
   const response = await fetch('https://api.uigf.org/md5/genshin')
   const responseJson = await response.json()
-  return responseJson[lang]
+  return responseJson
 }
 
 // initialize item id dictionary
 const initLookupTable = async () => {
-  // if itemIdDictMd5 != null, that means itemIdDict has been init, no need to do it again
-  if (itemIdDictMd5) {
+  // check if itemIdDict has been init, no need to do it again
+  if (itemIdDict.size > 0) {
     return
   }
 
-  // try to obtain dict md5
-  try {
-    itemIdDictMd5 = await fetchItemIdDictMd5()
-  } catch (e) {
-    console.log(`Unable to fetch latest item id dictionary md5 due to: ${e}`)
-  }
-
-  // if a locally cached dictionary does not exist
+  // if a locally cached dictionary does not exist, fetch a new copy
   if (!existsFile(itemIdDictFileName)) {
     await fetchItemIdDict();
     return;
   }
 
-  // if a locally cached dictionary is found
-  const data = await readJSON(itemIdDictFileName)
-  // if itemIdDictMd5 is not successfully fetched previously
-  if (!itemIdDictMd5 && data) itemIdDictMd5 = data.md5
-
-  // if the data is null or the md5 does not match
-  if (!data || data.md5 !== itemIdDictMd5) {
-    // console.log('md5 check failed! Re-fetching...')
-    await fetchItemIdDict()
-    return;
+  // fetch md5 of upstream dicts
+  let remoteItemIdDictMd5 = {}
+  try {
+    remoteItemIdDictMd5 = await fetchItemIdDictMd5()
+  } catch (e) {
+    console.log(`Unable to fetch latest item id dictionary md5 due to: ${e}`)
   }
 
-  // if the data is valid and the md5 matches
-  // console.log('md5 check success!')
-  data.lang.forEach(([lang, table]) => itemIdDict.set(lang, new Map(table)))
+
+  // if a locally cached dictionary is found
+  const localItemIdDict = await readJSON(itemIdDictFileName)
+  // if localItemIdDict is empty or old version
+  if (!localItemIdDict || typeof localItemIdDict.md5 === "string") {
+    await fetchItemIdDict()
+    return
+  }
+  // ensure all lang md5 matches
+  for (const lang in remoteItemIdDictMd5) {
+    if (remoteItemIdDictMd5[lang] !== localItemIdDict.md5[lang]) {
+      await fetchItemIdDict()
+      return
+    }
+  }
+
+  for (const lang in localItemIdDict.lang) {
+    itemIdDict.set(lang, new Map(Object.entries(localItemIdDict.lang[lang]).map(([name, id]) => [name, String(id)])))
+    itemIdDictMd5.set(lang, localItemIdDict.md5[lang])
+  }
 }
 
 // save item id dictionary
 const saveLookupTable = async () => {
-  await saveJSON(itemIdDictFileName, { lang: itemIdDict, md5: itemIdDictMd5 })
+  await saveJSON(itemIdDictFileName, { lang: mapToObject(itemIdDict), md5: mapToObject(itemIdDictMd5) })
 }
 
 // get item id
@@ -130,10 +135,10 @@ const getItemId = async (lang, name) => {
   if (!itemIdDict.has(lang) || !itemIdDict.get(lang).has(name)) {
     const response = await fetch(`https://api.uigf.org/identify/genshin/${name}`)
     const responseJson = await response.json()
-    if (!responseJson.item_id) {
+    if (response.status != 200) {
       throw new Error(`Couldn't find the item_id for the ${name}.`)
     }
-    itemIdDict.get(lang).set(name, responseJson.item_id.toString())
+    itemIdDict.get(lang).set(name, responseJson.matched[0].item_id.toString())
   }
   return itemIdDict.get(lang).get(name)
 }
@@ -201,7 +206,7 @@ const start = async () => {
   const result = await uigfJson()
   await saveLookupTable()
   const filePath = dialog.showSaveDialogSync({
-    defaultPath: path.join(app.getPath('downloads'), `UIGF_${result.info.uid}_${getTimeString()}`),
+    defaultPath: path.join(app.getPath('downloads'), `UIGF_${result.info.uid}_${getTimeString()}.json`),
     filters: [
       { name: 'JSON', extensions: ['json'] }
     ]

--- a/src/main/UIGFJson.js
+++ b/src/main/UIGFJson.js
@@ -8,10 +8,12 @@ const config = require('./config')
 const fetch = require('electron-fetch').default
 const { readJSON, saveJSON, existsFile, userDataPath, fixLocalMap, md5, mapToObject } = require('./utils')
 const Ajv = require('ajv')
+const Ajv2020 = require('ajv/dist/2020')
 
 // acquire uigf schema
-const validateUigfJson = new Ajv().compile(require('../schema/uigf.json'))
-const validateLocalJson = new Ajv().compile(require('../schema/local-data.json'))
+const validateUigf30Json = new Ajv({ strict: false }).compile(require('../schema/uigf3_0.json'))
+const validateUigf41Json = new Ajv2020({ strict: false }).compile(require('../schema/uigf4_1.json'))
+const validateLocalJson = new Ajv({ strict: false }).compile(require('../schema/local-data.json'))
 
 const uigfLangMap = new Map([
   ['zh-cn', 'chs'],
@@ -28,6 +30,7 @@ const uigfLangMap = new Map([
   ['th-th', 'th'],
   ['vi-vn', 'vi']
 ])
+const uigfRevLangMap = new Map(Array.from(uigfLangMap, ([key, value]) => [value, key]))
 
 const getTimeString = () => {
   return new Date().toLocaleString('sv').replace(/[- :]/g, '').slice(0, -2)
@@ -63,7 +66,7 @@ const itemIdDictMd5 = new Map()
 const itemIdDictFileName = 'item-id-dict.json'
 
 // acquire dictionary based on give language
-const fetchItemIdDict = async (lang = 'all') => {
+const fetchItemIdDict = async () => {
   // fetch item id dicts from api.uigf.org
   for (const [_, lang] of uigfLangMap) {
     const response = await fetch(`https://api.uigf.org/dict/genshin/${lang}.json`)
@@ -99,7 +102,7 @@ const initLookupTable = async () => {
   try {
     remoteItemIdDictMd5 = await fetchItemIdDictMd5()
   } catch (e) {
-    console.log(`Unable to fetch latest item id dictionary md5 due to: ${e}`)
+    console.error(`Unable to fetch latest item id dictionary md5 due to: ${e}`)
   }
 
 
@@ -146,14 +149,26 @@ const getItemId = async (lang, name) => {
 // get item id
 const fixUigfJson = (importData) => {
   // if item_id is missing, add placeholder item_id to importData
-  importData.list.forEach(e => {
-    if (!e.item_id) {
-      e.item_id = ""
+  try {
+    if (importData.list) { // v3.0
+      importData.list.forEach(item => {
+        if (!item.item_id) {
+          item.item_id = ""
+        }
+      })
+    } else if (importData.hk4e) { // v4.x
+      importData.hk4e.forEach(account => account.list.forEach((item) => {
+        if (!item.item_id) {
+          item.item_id = ""
+        }
+      }))
     }
-  })
+  } catch (e) {
+    console.error(`Failed to fix UIGF Json: ${e}`)
+  }
 }
 
-const uigfJson = async () => {
+const generateUigf30Json = async () => {
   const { dataMap, current } = getData()
   const data = dataMap.get(current)
   if (!data?.result.size) {
@@ -201,12 +216,68 @@ const uigfJson = async () => {
   return result
 }
 
-const start = async () => {
+const generateUigf41Json = async (uigfAllAccounts=true) => {
+  const { dataMap, current } = getData()
+  if (!Array.from(dataMap.entries()).reduce((accumulate, account) => accumulate + account[1].result.size, 0)) {
+    throw new Error('数据为空')
+  }
+  const result = {
+    info: {
+      export_timestamp: Math.round(Date.now() / 1000),
+      export_app: `genshin-wish-export`,
+      export_app_version: `v${version}`,
+      version: "v4.1"
+    },
+    hk4e: []
+  }
+  for (const [uid, data] of dataMap) {
+    if (!uigfAllAccounts && uid != current) continue
+    const uidMatch = uid.match(/^(?<prefix>\d{1,2})\d{8}$/) // match 1 or 2 digits followed by exactly 8 digits
+    const uidPrefix = uidMatch.groups.prefix
+    const uigfLang = uigfLangMap.get(data.lang) || uigfLangMap.get(fixLocalMap.get(data.lang))
+    const fakeId = fakeIdFn()
+    const account = {
+      uid: uid,
+      timezone: ['6'].includes(uidPrefix) ? -5 : ['7'].includes(uidPrefix) ? 1 : 8, // 6(America): TZ=-5, 7(Europe): TZ=1, All others TZ=8
+      lang: uigfRevLangMap.get(data.lang) || data.lang, // ensure long-format for lang
+      list: []
+    }
+    for (const [gachaType, gachaList] of data.result) {
+      for (const gacha of gachaList){
+        const gachaItem = {
+          uigf_gacha_type: gachaType,
+          gacha_type: gachaType,
+          item_id: await getItemId(uigfLang, gacha[1]),
+          // count: null, // optional and not included in stored data
+          time: gacha[0],
+          timestamp: new Date(gacha[0]).getTime(), // Used to sort list for in-order fakeIds
+          name: gacha[1],
+          item_type: gacha[2],
+          rank_type: `${gacha[3]}`,
+          id: shouldBeString(gacha[5]) || ''
+        }
+        account.list.push(gachaItem)
+      }
+    }
+    const sortedList = account.list.sort((itemA, itemB) => itemA.timestamp - itemB.timestamp)
+    for (const gachaItem of sortedList) {
+      delete gachaItem.timestamp
+      gachaItem.id = gachaItem.id || fakeId()
+    }
+    result.hk4e.push(account)
+  }
+  return result
+}
+
+const start = async (uigfVersion, uigfAllAccounts=true) => {
   await initLookupTable()
-  const result = await uigfJson()
+  const result = uigfVersion === "3.0" ? await generateUigf30Json() : await generateUigf41Json(uigfAllAccounts)
   await saveLookupTable()
+  const uid = uigfVersion === '3.0' ? result.info.uid : result.hk4e[0].uid
+  const numAccounts = uigfVersion === '3.0' ? 1 : result.hk4e.length
+  const uigfFileName = `UIGF_v${uigfVersion}` + (numAccounts > 1 ? '' : `_${uid}`) + `_${getTimeString()}.json`
   const filePath = dialog.showSaveDialogSync({
-    defaultPath: path.join(app.getPath('downloads'), `UIGF_${result.info.uid}_${getTimeString()}.json`),
+    defaultPath: path.join(app.getPath('downloads'), uigfFileName),
     filters: [
       { name: 'JSON', extensions: ['json'] }
     ]
@@ -225,6 +296,56 @@ const saveAndBackup = async (data) => {
   }
   await saveData(data)
   await changeCurrent(data.uid)
+}
+
+const importUgif30Json = async (importData) => {
+  console.log(importData)
+    const gachaData = {
+      result: new Map(),
+      time: Date.now(),
+      typeMap: getItemTypeNameMap(importData.info.lang),
+      uid: importData.info.uid,
+      lang: importData.info.lang
+    }
+    gachaData.typeMap.forEach((_, k) => gachaData.result.set(k, []))
+    importData.list.sort((a, b) => parseInt(BigInt(a.id) - BigInt(b.id)))
+    for (const item of importData.list) {
+      gachaData.result.get(item.uigf_gacha_type).push([
+        item.time,
+        item.name,
+        item.item_type,
+        parseInt(item.rank_type),
+        item.gacha_type,
+        item.id 
+      ])
+    }
+    await saveAndBackup(gachaData)
+}
+
+const importUgif41Json = async (importData) => {
+  for (const accountData of importData.hk4e) {
+      const gachaData = {
+        result: new Map(),
+        time: Date.now(),
+        typeMap: getItemTypeNameMap(accountData.lang),
+        uid: accountData.uid,
+        lang: accountData.lang
+      }
+      gachaData.typeMap.forEach((_, k) => gachaData.result.set(k, []))
+      accountData.list.sort((itemA, itemB) => parseInt(BigInt(itemA.id) - BigInt(itemB.id)))
+      for (const item of accountData.list) {
+        const gachaItem = [
+          item.time,
+          item.name,
+          item.item_type,
+          parseInt(item.rank_type),
+          item.gacha_type,
+          item.id
+        ]
+        gachaData.result.get(item.uigf_gacha_type).push(gachaItem)
+      }
+      await saveAndBackup(gachaData)
+  }
 }
 
 const importJson = async () => {
@@ -247,20 +368,10 @@ const importJson = async () => {
       // try to fix imported data when possible
       fixUigfJson(importData)
       // then validate imported data using schema
-      if (validateUigfJson(importData)) {
-        const gachaData = {
-          result: new Map(),
-          time: Date.now(),
-          typeMap: getItemTypeNameMap(importData.info.lang),
-          uid: importData.info.uid,
-          lang: importData.info.lang
-        }
-        gachaData.typeMap.forEach((_, k) => gachaData.result.set(k, []))
-        importData.list.sort((a, b) => parseInt(BigInt(a.id) - BigInt(b.id)))
-        for (const item of importData.list) {
-          gachaData.result.get(item.uigf_gacha_type).push([item.time, item.name, item.item_type, parseInt(item.rank_type), item.gacha_type, item.id])
-        }
-        await saveAndBackup(gachaData)
+      if (validateUigf30Json(importData)) {
+        await importUgif30Json(importData)
+      } else if (validateUigf41Json(importData)) {
+        await importUgif41Json(importData)
       } else {
         throw new Error(`JSON format error`)
       }
@@ -270,12 +381,12 @@ const importJson = async () => {
   }
 }
 
-ipcMain.handle('EXPORT_UIGF_JSON', async () => {
-  await start()
+ipcMain.handle('EXPORT_UIGF_JSON', async (event, uigfVersion, uigfAllAccounts=true) => {
+  await start(uigfVersion, uigfAllAccounts)
 })
 
 ipcMain.handle('IMPORT_UIGF_JSON', async () => {
   return await importJson()
 })
 
-module.exports = { uigfJson }
+module.exports = { generateUigf30Json, generateUigf41Json }

--- a/src/main/getData.js
+++ b/src/main/getData.js
@@ -470,8 +470,8 @@ ipcMain.handle('FORCE_READ_DATA', async () => {
   }
 })
 
-ipcMain.handle('CHANGE_UID', (event, uid) => {
-  config.current = uid
+ipcMain.handle('CHANGE_UID', async (event, uid) => {
+  await changeCurrent(uid)
 })
 
 ipcMain.handle('GET_CONFIG', () => {

--- a/src/main/gists.js
+++ b/src/main/gists.js
@@ -2,10 +2,10 @@ const {ipcMain} = require('electron')
 const config = require('./config')
 const {Octokit} = require('@octokit/core')
 const fetch = require('electron-fetch').default
-const { uigfJson } = require('./UIGFJson')
+const { generateUigf30Json } = require('./UIGFJson')
 
 const start = async () => {
-  const result = uigfJson()
+  const result = generateUigf30Json()
 
   if (!config.gistsToken) {
     throw new Error('未设置gistsToken')

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -192,6 +192,10 @@ const hash = (data, type = 'sha256') => {
   return hmac.digest('hex')
 }
 
+const md5 = (data) => {
+  return crypto.createHash('md5').update(data).digest('hex')
+}
+
 const scryptKey = crypto.scryptSync(userPath, 'hk4e', 24)
 const cipherAes = (data) => {
   const algorithm = 'aes-192-cbc'
@@ -240,8 +244,18 @@ async function getCacheText(gamePath) {
   return [cacheText, timeSortedFiles[0]]
 }
 
+const mapToObject = (map) => {
+  let newObject = Object.fromEntries(map)
+  for (const key of Object.keys(newObject)) {
+    if (newObject[key] instanceof Map) {
+      newObject[key] = mapToObject(newObject[key])
+    }
+  }
+  return newObject
+}
+
 module.exports = {
-  readdir, sleep, request, hash, cipherAes, decipherAes, saveLog,
+  readdir, sleep, request, hash, md5, cipherAes, decipherAes, saveLog,
   sendMsg, existsFile, readJSON, saveJSON, initWindow, getWin, localIp, userPath, detectLocale, langMap, fixLocalMap,
-  getCacheText, appRoot, userDataPath
+  getCacheText, appRoot, userDataPath, mapToObject
 }

--- a/src/renderer/components/Setting.vue
+++ b/src/renderer/components/Setting.vue
@@ -24,6 +24,15 @@
         <div class="flex space-x-2">
           <el-button :loading="data.loadingOfUIGFJSON" class="focus:outline-none" plain type="primary" @click="importUIGFJSON">{{ text.UIGFImportButton }}</el-button>
           <el-button :loading="data.loadingOfUIGFJSON" class="focus:outline-none" plain type="success" @click="exportUIGFJSON">{{ text.UIGFButton }}</el-button>
+          <el-select class="w-24" v-model="settingForm.uigfVersion">
+            <el-option
+              v-for="version in uigfSupportedVersions"
+              :key="version"
+              :label="'UIGFv' + version"
+              :value="version"
+            />
+          </el-select>
+          <el-checkbox v-if="settingForm.uigfVersion === uigfSupportedVersions[0]" v-model="settingForm.uigfAllAccounts">{{ text.UIGFAllAccounts }}</el-checkbox>
           <el-checkbox v-model="settingForm.readableJSON" @change="saveSetting">{{ text.UIGFReadable }}</el-checkbox>
         </div>
         <p class="text-gray-400 text-xs m-1.5 leading-normal">{{ text.UIGFHint }}
@@ -81,8 +90,15 @@ const settingForm = reactive({
   fetchFullHistory: false,
   hideNovice: true,
   gistsToken: '',
+  uigfVersion: "4.1",
+  uigfAllAccounts: true,
   readableJSON: false
 })
+
+const uigfSupportedVersions = [
+  "4.1",
+  "3.0"
+]
 
 const text = computed(() => props.i18n.ui.setting)
 const about = computed(() => props.i18n.ui.about)
@@ -111,7 +127,7 @@ const openLink = (link) => shell.openExternal(link)
 const exportUIGFJSON = async () => {
   data.loadingOfUIGFJSON = true
   try {
-    await ipcRenderer.invoke('EXPORT_UIGF_JSON')
+    await ipcRenderer.invoke('EXPORT_UIGF_JSON', settingForm.uigfVersion, settingForm.uigfAllAccounts)
   } catch (e) {
     ElMessage({
       message: e.message || e,

--- a/src/schema/uigf3_0.json
+++ b/src/schema/uigf3_0.json
@@ -1,5 +1,4 @@
 {
-  "_version": "2.4",
   "type": "object",
   "properties": {
     "info": {
@@ -7,41 +6,41 @@
       "properties": {
         "uid": {
           "type": "string",
-          "title": "导出记录的 UID"
+          "title": "UID of the export record"
         },
         "lang": {
           "type": "string",
-          "title": "语言 languagecode2-country/regioncode2"
+          "title": "language in the format of languagecode2-country/regioncode2"
         },
         "export_timestamp": {
           "type": "number",
-          "title": "导出 UNIX 时间戳（秒）"
+          "title": "Export UNIX timestamp (accurate to the second)"
         },
         "export_time": {
           "type": "string",
-          "title": "导出时间",
+          "title": "Export time",
           "description": "yyyy-MM-dd HH:mm:ss"
         },
         "export_app": {
           "type": "string",
-          "title": "导出 App 名称"
+          "title": "Name of the export application"
         },
         "export_app_version": {
           "type": "string",
-          "title": "导出 App 版本"
+          "title": "Version of the export application"
         },
         "uigf_version": {
           "type": "string",
-          "title": "UIGF 版本号",
+          "title": "UIGF version; follow the regular expression pattern",
           "pattern": "v\\d+\\.\\d+"
         },
         "region_time_zone": {
           "type": "number",
-          "title": "区域时区偏移"
+          "title": "Region timezone offset"
         }
       },
       "required": ["uid", "uigf_version"],
-      "title": "UIGF 导出信息"
+      "title": "UIGF Export Information"
     },
     "list": {
       "type": "array",
@@ -50,48 +49,48 @@
         "properties": {
           "uigf_gacha_type": {
             "type": "string",
-            "title": "UIGF 卡池类型",
-            "description": "用于区分卡池类型不同，但卡池保底计算相同的物品"
+            "title": "UIGF gacha type",
+            "description": "Used to differentiate different gacha types with the same pity calculation for items"
           },
           "gacha_type": {
             "type": "string",
-            "title": "卡池类型"
+            "title": "Gacha type"
           },
           "item_id": {
             "type": "string",
-            "title": "物品的内部 ID"
+            "title": "Internal ID of the item"
           },
           "count": {
             "type": "string",
-            "title": "个数，一般为1"
+            "title": "Count, usually 1"
           },
           "time": {
             "type": "string",
-            "title": "获取物品的时间"
+            "title": "Time when the item was obtained. This MUST BE THE String typed value captured intact from the gacha record webpage WITHOUT ANY CONVERTION TO ANY DATE TYPES. Any conversion of such can cause potential timezone mistakes if the device time zone differs from the server time zone, unless special treatments are applied by individual app devs."
           },
           "name": {
             "type": "string",
-            "title": "物品名称"
+            "title": "Item name"
           },
           "item_type": {
             "type": "string",
-            "title": "物品类型"
+            "title": "Item type"
           },
           "rank_type": {
             "type": "string",
-            "title": "物品等级"
+            "title": "Item rank"
           },
           "id": {
             "type": "string",
-            "title": "记录内部 ID"
+            "title": "Internal ID of the record"
           }
         },
         "required": ["uigf_gacha_type", "gacha_type", "id", "item_id", "time"],
-        "title": "UIGF 物品"
+        "title": "UIGF Item"
       },
-      "title": "物品列表"
+      "title": "Item List"
     }
   },
   "required": ["info", "list"],
-  "title": "UIGF 根对象"
+  "title": "UIGF Root Object"
 }

--- a/src/schema/uigf4_1.json
+++ b/src/schema/uigf4_1.json
@@ -1,0 +1,372 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "info": {
+            "type": "object",
+            "properties": {
+                "export_timestamp": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "description": "The timestamp of the export, in seconds"
+                },
+                "export_app": {
+                    "type": "string",
+                    "description": "The name of the application that exported the archive"
+                },
+                "export_app_version": {
+                    "type": "string",
+                    "description": "The version of the app that exported the archive"
+                },
+                "version": {
+                    "type": "string",
+                    "pattern": "^v\\d+\\.\\d+$",
+                    "description": "The UIGF version of the exported archive, formatted as 'v{major}.{minor}', e.g., v4.0"
+                }
+            },
+            "required": [
+                "export_timestamp",
+                "export_app",
+                "export_app_version",
+                "version"
+            ]
+        },
+        "hk4e": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "uid": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            }
+                        ],
+                        "description": "UID"
+                    },
+                    "timezone": {
+                        "type": "integer",
+                        "description": "Time zone offset"
+                    },
+                    "lang": {
+                        "type": "string",
+                        "description": "Language code",
+                        "enum": [
+                            "de-de",
+                            "en-us",
+                            "es-es",
+                            "fr-fr",
+                            "id-id",
+                            "it-it",
+                            "ja-jp",
+                            "ko-kr",
+                            "pt-pt",
+                            "ru-ru",
+                            "th-th",
+                            "tr-tr",
+                            "vi-vn",
+                            "zh-cn",
+                            "zh-tw"
+                        ]
+                    },
+                    "list": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "uigf_gacha_type": {
+                                    "type": "string",
+                                    "description": "UIGF gacha type, used to distinguish between different gacha types that have the same pity calculation",
+                                    "enum": [
+                                        "100",
+                                        "200",
+                                        "301",
+                                        "302",
+                                        "500"
+                                    ]
+                                },
+                                "gacha_type": {
+                                    "type": "string",
+                                    "description": "Gacha type, returned by MiHoYo API",
+                                    "enum": [
+                                        "100",
+                                        "200",
+                                        "301",
+                                        "302",
+                                        "400",
+                                        "500"
+                                    ]
+                                },
+                                "item_id": {
+                                    "type": "string",
+                                    "description": "The internal ID of the item"
+                                },
+                                "count": {
+                                    "type": "string",
+                                    "description": "The number of items, usually 1, returned by MiHoYo API"
+                                },
+                                "time": {
+                                    "type": "string",
+                                    "description": "The local time in the timezone of the item being drawn"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "The name of the item, returned by MiHoYo API"
+                                },
+                                "item_type": {
+                                    "type": "string",
+                                    "description": "The type of the item, returned by MiHoYo API"
+                                },
+                                "rank_type": {
+                                    "type": "string",
+                                    "description": "The rank of the item, returned by MiHoYo API"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "The internal ID of the record, returned by MiHoYo API"
+                                }
+                            },
+                            "required": [
+                                "uigf_gacha_type",
+                                "gacha_type",
+                                "item_id",
+                                "time",
+                                "id"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "uid",
+                    "timezone",
+                    "list"
+                ]
+            }
+        },
+        "hkrpg": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "uid": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            }
+                        ],
+                        "description": "UID"
+                    },
+                    "timezone": {
+                        "type": "integer",
+                        "description": "Time zone offset"
+                    },
+                    "lang": {
+                        "type": "string",
+                        "description": "Language code",
+                        "enum": [
+                            "de-de",
+                            "en-us",
+                            "es-es",
+                            "fr-fr",
+                            "id-id",
+                            "it-it",
+                            "ja-jp",
+                            "ko-kr",
+                            "pt-pt",
+                            "ru-ru",
+                            "th-th",
+                            "tr-tr",
+                            "vi-vn",
+                            "zh-cn",
+                            "zh-tw"
+                        ]
+                    },
+                    "list": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "gacha_id": {
+                                    "type": "string",
+                                    "description": "Gacha Pool ID"
+                                },
+                                "gacha_type": {
+                                    "type": "string",
+                                    "description": "Gacha type",
+                                    "enum": [
+                                        "1",
+                                        "2",
+                                        "11",
+                                        "12",
+                                        "21",
+                                        "22"
+                                    ]
+                                },
+                                "item_id": {
+                                    "type": "string",
+                                    "description": "The internal ID of the item"
+                                },
+                                "count": {
+                                    "type": "string",
+                                    "description": "The number of items, usually 1, returned by MiHoYo API"
+                                },
+                                "time": {
+                                    "type": "string",
+                                    "description": "The local time in the timezone of the item being drawn"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "The name of the item, returned by MiHoYo API"
+                                },
+                                "item_type": {
+                                    "type": "string",
+                                    "description": "The type of the item, returned by MiHoYo API"
+                                },
+                                "rank_type": {
+                                    "type": "string",
+                                    "description": "The rank of the item, returned by MiHoYo API"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "The internal ID of the record, returned by MiHoYo API"
+                                }
+                            },
+                            "required": [
+                                "gacha_type",
+                                "gacha_id",
+                                "time",
+                                "item_id",
+                                "id"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "uid",
+                    "timezone",
+                    "list"
+                ]
+            }
+        },
+        "nap": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "uid": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            }
+                        ],
+                        "description": "UID"
+                    },
+                    "timezone": {
+                        "type": "integer",
+                        "description": "Time zone offset"
+                    },
+                    "lang": {
+                        "type": "string",
+                        "description": "Language code",
+                        "enum": [
+                            "de-de",
+                            "en-us",
+                            "es-es",
+                            "fr-fr",
+                            "id-id",
+                            "it-it",
+                            "ja-jp",
+                            "ko-kr",
+                            "pt-pt",
+                            "ru-ru",
+                            "th-th",
+                            "tr-tr",
+                            "vi-vn",
+                            "zh-cn",
+                            "zh-tw"
+                        ]
+                    },
+                    "list": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "gacha_id": {
+                                    "type": "string",
+                                    "description": "Gacha Pool ID"
+                                },
+                                "gacha_type": {
+                                    "type": "string",
+                                    "description": "Gacha type",
+                                    "enum": [
+                                        "1",
+                                        "2",
+                                        "3",
+                                        "5"
+                                    ]
+                                },
+                                "item_id": {
+                                    "type": "string",
+                                    "description": "The internal ID of the item"
+                                },
+                                "count": {
+                                    "type": "string",
+                                    "description": "The number of items, usually 1, returned by MiHoYo API"
+                                },
+                                "time": {
+                                    "type": "string",
+                                    "description": "The local time in the timezone of the item being drawn"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "The name of the item, returned by MiHoYo API"
+                                },
+                                "item_type": {
+                                    "type": "string",
+                                    "description": "The type of the item, returned by MiHoYo API"
+                                },
+                                "rank_type": {
+                                    "type": "string",
+                                    "description": "The rank of the item, returned by MiHoYo API"
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "description": "The internal ID of the record, returned by MiHoYo API"
+                                }
+                            },
+                            "required": [
+                                "gacha_type",
+                                "item_id",
+                                "time",
+                                "id"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "uid",
+                    "timezone",
+                    "list"
+                ]
+            }
+        }
+    },
+    "required": [
+        "info"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,7 +456,17 @@ ajv-keywords@^3.4.1:
   resolved "https://registry.npmmirror.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@6, ajv@^6.10.0, ajv@^6.12.0:
+ajv@8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
+ajv@^6.10.0, ajv@^6.12.0:
   version "6.12.6"
   resolved "https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1599,7 +1609,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.npmmirror.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -1631,6 +1641,11 @@ fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-uri@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
+  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
 fastq@^1.6.0:
   version "1.11.0"
@@ -2188,6 +2203,11 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stringify-safe@^5.0.1:
   version "5.0.1"
@@ -2971,6 +2991,11 @@ require-directory@^2.1.1:
   resolved "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -3216,7 +3241,16 @@ stat-mode@^1.0.0:
   resolved "https://registry.npmmirror.com/stat-mode/-/stat-mode-1.0.0.tgz#68b55cb61ea639ff57136f36b216a291800d1465"
   integrity sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3248,7 +3282,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3268,6 +3302,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -3504,7 +3545,16 @@ winreg@^1.2.4:
   resolved "https://registry.npmmirror.com/winreg/-/winreg-1.2.4.tgz#ba065629b7a925130e15779108cf540990e98d1b"
   integrity sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
The UIGF api no longer seems to accept `/dict/genshin/all.json` requests, and the `/md5/genshin` endpoint no longer includes a hash for `all`. This patch now makes the tool loop through all the supported languages and fetches them individually, and calculates the hashes locally as the `/md5/genshin` seems to not include many of the other languages.