### PR TITLE
Update gacha_type assignment to use gacha[4]

### DIFF
--- a/src/main/UIGFJson.js
+++ b/src/main/UIGFJson.js
@@ -257,7 +257,7 @@ const generateUigf41Json = async (uigfAllAccounts=true) => {
       for (const gacha of gachaList){
         const gachaItem = {
           uigf_gacha_type: gachaType,
-          gacha_type: gachaType,
+          gacha_type: shouldBeString(gacha[4]) || gachaType,
           item_id: await getItemId(uigfLang, gacha[1]),
           // count: null, // optional and not included in stored data
           time: gacha[0],


### PR DESCRIPTION
Fix the bug where gacha_type for "Wish-2" is incorrect when exporting in UIGF v4.1 format.